### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/hipnat</archive>
 		</mailingList>
 	</mailingLists>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<name>hIPNAT</name>
 	<description>(highly capable) Image Processing Tools for Neuroanatomy and Tree-like structures</description>
-	<url>http://imagej.net/Neuroanatomy</url>
+	<url>https://imagej.net/Neuroanatomy</url>
 	<inceptionYear>2016</inceptionYear>
 	<organization>
 		<name>Fiji</name>
@@ -32,7 +32,7 @@
 		<developer>
 			<id>tferr</id>
 			<name>Tiago Ferreira</name>
-			<url>http://imagej.net/User:Tiago</url>
+			<url>https://imagej.net/User:Tiago</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>14.0.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -83,8 +83,8 @@
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.